### PR TITLE
refactor: change terminal config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,19 +39,33 @@ Currently only supports Maven projects.
 
 ```lua
 local config = {
-  use_maven_wrapper = false,
-  hide_terminal = true,
-  terminal_height = 25,
-  terminal_width = 90,
-  terminal_border = "curved",
-  display_name = "mvn test",
-  title_pos = "center",
-  direction = "float",
-  auto_scroll = true,
-  close_on_exit = false,
-  timeout_len = 5000,
+  use_wrapper = false,
+  timeout_len = 2000,
   toggle_key = "<leader>Mm",
   close_key = "q",
+  max_history_size = 12,
+  terminal = {
+    -- Default terminal configuration
+    hidden = true,
+    direction = "float",
+    auto_scroll = true,
+    close_on_exit = false,
+    float_opts = {
+      border = "curved",
+      height = 25,
+      width = 90,
+      title_pos = "center",
+      highlights = {
+        Normal = { link = "Normal" },
+        FloatBorder = { link = "FloatBorder" },
+      },
+    },
+    -- You can override any terminal option here
+    -- env = { MY_VAR = "value" },
+    -- clear_env = false,
+    -- on_create = function(term) end,
+    -- etc.
+  },
 }
 ```
 

--- a/doc/java-test-util.txt
+++ b/doc/java-test-util.txt
@@ -49,19 +49,33 @@ DEFAULT CONFIG ~
   - plugin currently only supports floating terminal
 >lua
     local config = {
-      use_maven_wrapper = false,
-      hide_terminal = true,
-      terminal_height = 25,
-      terminal_width = 90,
-      terminal_border = "curved",
-      display_name = "mvn test",
-      title_pos = "center",
-      direction = "float",
-      auto_scroll = true,
-      close_on_exit = false,
-      timeout_len = 5000,
+      use_wrapper = false,
+      timeout_len = 2000,
       toggle_key = "<leader>Mm",
       close_key = "q",
+      max_history_size = 12,
+      terminal = {
+        -- Default terminal configuration
+        hidden = true,
+        direction = "float",
+        auto_scroll = true,
+        close_on_exit = false,
+        float_opts = {
+          border = "curved",
+          height = 25,
+          width = 90,
+          title_pos = "center",
+          highlights = {
+            Normal = { link = "Normal" },
+            FloatBorder = { link = "FloatBorder" },
+          },
+        },
+        -- You can override any terminal option here
+        -- env = { MY_VAR = "value" },
+        -- clear_env = false,
+        -- on_create = function(term) end,
+        -- etc.
+      },
     }
 <
 

--- a/lua/java_test_util/config.lua
+++ b/lua/java_test_util/config.lua
@@ -1,35 +1,56 @@
+---@class TerminalConfig
+---@field newline_chr string?
+---@field direction string? the layout style for the terminal
+---@field hidden boolean? whether or not to include this terminal in the terminals list
+---@field close_on_exit boolean? whether or not to close the terminal window when the process exits
+---@field auto_scroll boolean? whether or not to scroll down on terminal output
+---@field float_opts table<string, any>?
+---@field display_name string?
+---@field env table<string, string>? environmental variables passed to jobstart()
+---@field clear_env boolean? use clean job environment, passed to jobstart()
+---@field on_stdout fun(t: Terminal, job: number, data: string[]?, name: string?)?
+---@field on_stderr fun(t: Terminal, job: number, data: string[], name: string)?
+---@field on_exit fun(t: Terminal, job: number, exit_code: number?, name: string?)?
+---@field on_create fun(term:Terminal)?
+---@field on_open fun(term:Terminal)?
+---@field on_close fun(term:Terminal)?
+---@field dir string? the directory for the terminal
+---@field name string? the name of the terminal
+---@field count number? the count that triggers that specific terminal
+---@field highlights table<string, table<string, string>>?
+
 ---@class Config
 ---@field use_wrapper boolean
----@field hide_terminal boolean
----@field terminal_height number
----@field terminal_width number
----@field terminal_border string
----@field display_name string
----@field title_pos string
----@field direction string
----@field auto_scroll boolean
----@field close_on_exit boolean
 ---@field timeout_len number
 ---@field toggle_key string
 ---@field close_key string
 ---@field max_history_size number
+---@field terminal TerminalConfig
 
 ---@type Config
 local config = {
   use_wrapper = false,
-  hide_terminal = true,
-  terminal_height = 25,
-  terminal_width = 90,
-  terminal_border = "curved",
-  display_name = "mvn test",
-  title_pos = "center",
-  direction = "float",
-  auto_scroll = true,
-  close_on_exit = false,
   timeout_len = 2000,
   toggle_key = "<leader>Mm",
   close_key = "q",
   max_history_size = 12,
+  terminal = {
+    -- Default terminal configuration based on current usage
+    hidden = true,
+    direction = "float",
+    auto_scroll = true,
+    close_on_exit = false,
+    float_opts = {
+      border = "curved",
+      height = 25,
+      width = 90,
+      title_pos = "center",
+      highlights = {
+        Normal = { link = "Normal" },
+        FloatBorder = { link = "FloatBorder" },
+      },
+    },
+  },
 }
 
 return config

--- a/lua/java_test_util/terminal.lua
+++ b/lua/java_test_util/terminal.lua
@@ -66,33 +66,20 @@ function M.run_command_in_terminal(command, component, type)
     history.save_to_history(command, component, type)
   end
 
-  local float_term = terminal:new({
+  -- Create terminal configuration by merging user config with defaults
+  local terminal_config = vim.tbl_deep_extend("force", {
     cmd = command,
-    hidden = shared.config.hide_terminal,
     _display_name = function(_)
       return " 󰂓 " .. component .. ":" .. type:upper()
     end,
-
     display_name = function(_)
       return " 󰂓 " .. component .. ":" .. type:upper()
     end,
-    direction = shared.config.direction,
-    auto_scroll = shared.config.auto_scroll,
-    close_on_exit = shared.config.close_on_exit,
-    -- title = " 󰂓 " .. component .. type:upper(),
     float_opts = {
-      border = shared.config.terminal_border,
-      height = shared.config.terminal_height,
-      width = shared.config.terminal_width,
-      title_pos = shared.config.title_pos,
       title = " 󰂓 " .. component .. ":" .. type:upper(),
       display_name = " 󰂓 " .. component .. ":" .. type:upper(),
       float_name = " 󰂓 " .. component .. ":" .. type:upper(),
       float_title = " 󰂓 " .. component .. ":" .. type:upper(),
-      highlights = {
-        Normal = { link = "Normal" },
-        FloatBorder = { link = "FloatBorder" },
-      },
     },
     on_open = function(term)
       vim.api.nvim_buf_set_keymap(
@@ -108,18 +95,20 @@ function M.run_command_in_terminal(command, component, type)
       vim.cmd("startinsert!")
     end,
     on_stderr = function(_, _, _, _)
-      vim.notify(" Test failed")
+      vim.notify(" Test failed")
     end,
     on_exit = function(_, _, exit_code, _)
       if exit_code == 0 then
-        utils.show_message_until(" Tests passed", timeoutlen)
+        utils.show_message_until(" Tests passed", timeoutlen)
       elseif exit_code == 1 then
-        utils.show_message_until(" Tests failed", timeoutlen, vim.log.levels.ERROR)
+        utils.show_message_until(" Tests failed", timeoutlen, vim.log.levels.ERROR)
       end
     end,
-  })
+  }, shared.config.terminal or {})
 
-  if shared.config.hide_terminal == true then
+  local float_term = terminal:new(terminal_config)
+
+  if shared.config.terminal.hidden == true then
     float_term:spawn()
   else
     float_term:toggle()

--- a/tests/unit/terminal_spec.lua
+++ b/tests/unit/terminal_spec.lua
@@ -69,18 +69,18 @@ describe("terminal:", function()
     assert.stub(terminal.new).was_called(2)
   end)
 
-  it("should run tests on the background if hide_terminal is true", function()
+  it("should run tests on the background if terminal.hidden is true", function()
     -- Arrange
-    require("java_test_util").setup({ hide_terminal = true })
+    require("java_test_util").setup({ terminal = { hidden = true } })
     -- Act
     M.run_command_in_terminal("mvn test", "all tests", TestType.ALL)
     -- Assert
     assert.stub(mock_term.spawn).was_called()
   end)
 
-  it("should run tests on the foreground if hide_terminal is false", function()
+  it("should run tests on the foreground if terminal.hidden is false", function()
     -- Arrange
-    require("java_test_util").setup({ hide_terminal = false })
+    require("java_test_util").setup({ terminal = { hidden = false } })
     -- Act
     M.run_command_in_terminal("mvn test", "all tests", TestType.ALL)
     -- Assert


### PR DESCRIPTION
allow more customisation options by passing the whole config instead of
just selected fields
